### PR TITLE
Update tdr-graphql-client dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.54"
   lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val lambdaEvents = "com.amazonaws" % "aws-lambda-java-events" % "2.2.9"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.14"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.19"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0"
   lazy val keycloakMock = "com.tngtech.keycloakmock" % "mock" % "0.3.0"

--- a/src/test/scala/uk/gov/nationalarchives/api/update/ApiUpdateTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/ApiUpdateTest.scala
@@ -68,7 +68,7 @@ class ApiUpdateTest extends ExternalServicesTest with MockitoSugar with EitherVa
     val variables = Variables()
 
     when(keycloakUtils.serviceAccountToken[Identity](any[String], any[String])(any[SttpBackend[Identity, Nothing, NothingT]], any[ClassTag[Identity[_]]]))
-      .thenThrow(HttpError("An error occurred contacting the auth server"))
+      .thenThrow(HttpError("An error occurred contacting the auth server", StatusCode.InternalServerError))
 
     val exception = intercept[HttpError] {
       ApiUpdate().send(keycloakUtils, client, document, variables).futureValue


### PR DESCRIPTION
This upgrades the STTP dependency, which requires you to pass in a status code when returning an HTTP error.