### PR TITLE
Upgrade tdr-generated-graphql

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % "0.13.0"
   lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.13.0"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.54"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.60"
   lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val lambdaEvents = "com.amazonaws" % "aws-lambda-java-events" % "2.2.9"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"

--- a/src/test/resources/json/graphql_valid_av_expected.json
+++ b/src/test/resources/json/graphql_valid_av_expected.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation AddAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software value softwareVersion databaseVersion result datetime}}",
+  "query": "mutation AddAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
   "variables": {
     "input": {
       "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",

--- a/src/test/resources/json/graphql_valid_av_multiple_records_expected_1.json
+++ b/src/test/resources/json/graphql_valid_av_multiple_records_expected_1.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation AddAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software value softwareVersion databaseVersion result datetime}}",
+  "query": "mutation AddAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
   "variables": {
     "input": {
       "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",

--- a/src/test/resources/json/graphql_valid_av_multiple_records_expected_2.json
+++ b/src/test/resources/json/graphql_valid_av_multiple_records_expected_2.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation AddAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software value softwareVersion databaseVersion result datetime}}",
+  "query": "mutation AddAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
   "variables": {
     "input": {
       "fileId": "942ae85c-5f2a-4d70-b919-f6e14acf3f07",


### PR DESCRIPTION
The latest version of this dependency removes the `value` field from the antivirus metadata, which was never used. The antivirus result is is stored in the `result` field.