### PR TITLE
Make antivirus fields mandatory

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % "0.13.0"
   lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.13.0"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.60"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.61"
   lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val lambdaEvents = "com.amazonaws" % "aws-lambda-java-events" % "2.2.9"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"

--- a/src/test/resources/json/function_valid_av_input.json
+++ b/src/test/resources/json/function_valid_av_input.json
@@ -1,1 +1,8 @@
-{"fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b", "result": "something", "datetime": 1}
+{
+  "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",
+  "result": "some result",
+  "software": "some software",
+  "softwareVersion": "some software version",
+  "databaseVersion": "some database version",
+  "datetime": 1
+}

--- a/src/test/resources/json/function_valid_second_av_input.json
+++ b/src/test/resources/json/function_valid_second_av_input.json
@@ -1,1 +1,8 @@
-{"fileId": "942ae85c-5f2a-4d70-b919-f6e14acf3f07", "result": "something else", "datetime": 2}
+{
+  "fileId": "942ae85c-5f2a-4d70-b919-f6e14acf3f07",
+  "result": "something else",
+  "software": "other software",
+  "softwareVersion": "other software version",
+  "databaseVersion": "other database version",
+  "datetime": 2
+}

--- a/src/test/resources/json/graphql_valid_av_expected.json
+++ b/src/test/resources/json/graphql_valid_av_expected.json
@@ -3,7 +3,10 @@
   "variables": {
     "input": {
       "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",
-      "result": "something",
+      "software" : "some software",
+      "softwareVersion" : "some software version",
+      "databaseVersion" : "some database version",
+      "result" : "some result",
       "datetime": 1
     }
   }

--- a/src/test/resources/json/graphql_valid_av_multiple_records_expected_1.json
+++ b/src/test/resources/json/graphql_valid_av_multiple_records_expected_1.json
@@ -3,7 +3,10 @@
   "variables": {
     "input": {
       "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",
-      "result": "something",
+      "result": "some result",
+      "software": "some software",
+      "softwareVersion": "some software version",
+      "databaseVersion": "some database version",
       "datetime": 1
     }
   }

--- a/src/test/resources/json/graphql_valid_av_multiple_records_expected_2.json
+++ b/src/test/resources/json/graphql_valid_av_multiple_records_expected_2.json
@@ -4,6 +4,9 @@
     "input": {
       "fileId": "942ae85c-5f2a-4d70-b919-f6e14acf3f07",
       "result": "something else",
+      "software": "other software",
+      "softwareVersion": "other software version",
+      "databaseVersion": "other database version",
       "datetime": 2
     }
   }


### PR DESCRIPTION
Upgrade the tdr-generated-graphql dependency, which makes the antivirus update fields mandatory, since they are now required by the API.

They are always provided by the antivirus check message, so this is safe to do.