### PR TITLE
Add missing logback config file

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"application":"tdr-api-update"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="json" />
+    </root>
+</configuration>


### PR DESCRIPTION
Logging was added in bc4759a4ec6d9e40925f5258ce5bc56430fcd2fe, but I forgot the configuration file.

The logback file configures the logs in a JSON format, which makes it easier for us to search the log output by field in CloudWatch.