### PR TITLE
Log the time taken as json.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -12,6 +12,7 @@ import uk.gov.nationalarchives.api.update.Decoders._
 import uk.gov.nationalarchives.aws.utils.Clients.{kms, sqs}
 import uk.gov.nationalarchives.aws.utils.{KMSUtils, SQSUtils}
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -28,6 +29,7 @@ class Lambda {
   val sqsUtils: SQSUtils = SQSUtils(sqs)
 
   def update(event: SQSEvent, context: Context): Unit = {
+    implicit val startTime: Instant = Instant.now
     case class BodyWithReceiptHandle(body: String, receiptHandle: String)
 
     logger.info("Running API update with {} messages", value("messageCount", event.getRecords.size()))

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Processor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Processor.scala
@@ -55,7 +55,7 @@ trait Processor[Input, Data, Variables] {
         logSuccess(input)
         SQSUpdate(sqsClient).deleteSqsMessage(config("sqs.url"), receiptHandle)
         logSqsUpdate(input)
-        s"$input was successful"
+        fileId(input).toString
       })
       .recover(e => {
         logError(input, e)

--- a/src/test/scala/uk/gov/nationalarchives/api/update/ResultCollectorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/ResultCollectorTest.scala
@@ -12,9 +12,11 @@ import uk.gov.nationalarchives.api.update.utils.ExternalServicesTest
 import uk.gov.nationalarchives.aws.utils.SQSUtils
 import uk.gov.nationalarchives.tdr.error.HttpException
 
+import java.time.Instant
 import scala.concurrent.Future
 
 class ResultCollectorTest extends ExternalServicesTest with MockitoSugar with EitherValues with ScalaFutures {
+  implicit val startTime: Instant = Instant.now
 
   val config: Map[String, String] = Map("sqs.url" -> queueUrl)
 


### PR DESCRIPTION
This allows the performance checks to work out how long each lambda has
taken to run.

We may move this to the database in the future but this works for now.
