### PR TITLE
Use updated input names.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.285"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.286"
   lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.2"
   lazy val lambdaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.74"

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Decoders.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Decoders.scala
@@ -1,13 +1,14 @@
 package uk.gov.nationalarchives.api.update
 
-import graphql.codegen.types.{AddAntivirusMetadataInput, AddFileMetadataWithFileIdInput, FFIDMetadataInput}
+import graphql.codegen.types.{AddAntivirusMetadataInputValues, AddFileMetadataWithFileIdInput, FFIDMetadataInputValues}
 import io.circe.Decoder
+
 import io.circe.generic.semiauto.deriveDecoder
 
 object Decoders {
-  val antivirusDecoder: Decoder[Serializable] = deriveDecoder[AddAntivirusMetadataInput].map[Serializable](identity)
+  val antivirusDecoder: Decoder[Serializable] = deriveDecoder[AddAntivirusMetadataInputValues].map[Serializable](identity)
   val metadataDecoder: Decoder[Serializable] = deriveDecoder[AddFileMetadataWithFileIdInput].map[Serializable](identity)
-  val ffidMetadataDecoder: Decoder[Serializable] = deriveDecoder[FFIDMetadataInput].map[Serializable](identity)
+  val ffidMetadataDecoder: Decoder[Serializable] = deriveDecoder[FFIDMetadataInputValues].map[Serializable](identity)
 
   implicit val allDecoder: Decoder[Serializable] = antivirusDecoder.or(metadataDecoder).or(ffidMetadataDecoder)
 }

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
-import graphql.codegen.types.{AddAntivirusMetadataInput, AddFileMetadataWithFileIdInput, FFIDMetadataInput}
+import graphql.codegen.types.{AddAntivirusMetadataInputValues, AddFileMetadataWithFileIdInput, FFIDMetadataInputValues}
 import io.circe.parser.decode
 import net.logstash.logback.argument.StructuredArguments.value
 import software.amazon.awssdk.http.apache.ApacheHttpClient
@@ -57,13 +57,13 @@ class Lambda {
       .map(r => BodyWithReceiptHandle(r.getBody, r.getReceiptHandle))
       .map(bodyWithReceiptHandle => {
         decode[Serializable](bodyWithReceiptHandle.body).map {
-          case avInput: AddAntivirusMetadataInput =>
+          case avInput: AddAntivirusMetadataInputValues =>
             val processor = new AntivirusProcessor(config)
             processor.process(avInput, bodyWithReceiptHandle.receiptHandle)
           case fileMetadataInput: AddFileMetadataWithFileIdInput =>
             val processor = new FileMetadataProcessor(config)
             processor.process(fileMetadataInput, bodyWithReceiptHandle.receiptHandle)
-          case ffidMetadataInput: FFIDMetadataInput =>
+          case ffidMetadataInput: FFIDMetadataInputValues =>
             val processor = new FileFormatProcessor(config)
             processor.process(ffidMetadataInput, bodyWithReceiptHandle.receiptHandle)
         }.left.map(circeError =>

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Processor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Processor.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.Logger
 import graphql.codegen.AddAntivirusMetadata.{addAntivirusMetadata => avm}
 import graphql.codegen.AddFFIDMetadata.{addFFIDMetadata => afim}
 import graphql.codegen.AddFileMetadata.{addFileMetadata => afm}
-import graphql.codegen.types.{AddAntivirusMetadataInput, AddFileMetadataWithFileIdInput, FFIDMetadataInput}
+import graphql.codegen.types.{AddAntivirusMetadataInputValues, AddFileMetadataWithFileIdInput, FFIDMetadataInputValues}
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.{Decoder, Encoder}
 import net.logstash.logback.argument.StructuredArguments.value
@@ -93,14 +93,14 @@ trait Processor[Input, Data, Variables] {
 }
 
 class AntivirusProcessor(val config: Map[String, String])(implicit val executionContext: ExecutionContext)
-  extends Processor[AddAntivirusMetadataInput, avm.Data, avm.Variables] {
+  extends Processor[AddAntivirusMetadataInputValues, avm.Data, avm.Variables] {
   override val graphQlQuery: Document = avm.document
-  override def variables(input: AddAntivirusMetadataInput): avm.Variables = avm.Variables(input)
+  override def variables(input: AddAntivirusMetadataInputValues): avm.Variables = avm.Variables(input)
   override def dataDecoder: Decoder[avm.Data] = deriveDecoder[avm.Data]
   override def variablesEncoder: Encoder[avm.Variables] = avm.Variables.jsonEncoder
 
-  override def fileCheckName(input: AddAntivirusMetadataInput): String = "antivirus"
-  override def fileId(input: AddAntivirusMetadataInput): UUID = input.fileId
+  override def fileCheckName(input: AddAntivirusMetadataInputValues): String = "antivirus"
+  override def fileId(input: AddAntivirusMetadataInputValues): UUID = input.fileId
 }
 
 class FileMetadataProcessor(val config: Map[String, String])(implicit val executionContext: ExecutionContext)
@@ -115,12 +115,12 @@ class FileMetadataProcessor(val config: Map[String, String])(implicit val execut
 }
 
 class FileFormatProcessor(val config: Map[String, String])(implicit val executionContext: ExecutionContext)
-  extends Processor[FFIDMetadataInput, afim.Data, afim.Variables] {
+  extends Processor[FFIDMetadataInputValues, afim.Data, afim.Variables] {
   override val graphQlQuery: Document = afim.document
-  override def variables(input: FFIDMetadataInput): afim.Variables = afim.Variables(input)
+  override def variables(input: FFIDMetadataInputValues): afim.Variables = afim.Variables(input)
   override def dataDecoder: Decoder[afim.Data] = deriveDecoder[afim.Data]
   override def variablesEncoder: Encoder[afim.Variables] = afim.Variables.jsonEncoder
 
-  override def fileCheckName(input: FFIDMetadataInput): String = "FFID"
-  override def fileId(input: FFIDMetadataInput): UUID = input.fileId
+  override def fileCheckName(input: FFIDMetadataInputValues): String = "FFID"
+  override def fileId(input: FFIDMetadataInputValues): UUID = input.fileId
 }

--- a/src/test/resources/json/graphql_valid_av_expected.json
+++ b/src/test/resources/json/graphql_valid_av_expected.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation addAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
+  "query": "mutation addAntivirusMetadata($input:AddAntivirusMetadataInputValues!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
   "variables": {
     "input": {
       "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",

--- a/src/test/resources/json/graphql_valid_av_multiple_records_expected_1.json
+++ b/src/test/resources/json/graphql_valid_av_multiple_records_expected_1.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation addAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
+  "query": "mutation addAntivirusMetadata($input:AddAntivirusMetadataInputValues!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
   "variables": {
     "input": {
       "fileId": "4e0fd35b-8d6f-4498-b081-f7401ce6b99b",

--- a/src/test/resources/json/graphql_valid_av_multiple_records_expected_2.json
+++ b/src/test/resources/json/graphql_valid_av_multiple_records_expected_2.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation addAntivirusMetadata($input:AddAntivirusMetadataInput!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
+  "query": "mutation addAntivirusMetadata($input:AddAntivirusMetadataInputValues!){addAntivirusMetadata(addAntivirusMetadataInput:$input){fileId software softwareVersion databaseVersion result datetime}}",
   "variables": {
     "input": {
       "fileId": "942ae85c-5f2a-4d70-b919-f6e14acf3f07",

--- a/src/test/resources/json/graphql_valid_ffid_expected.json
+++ b/src/test/resources/json/graphql_valid_ffid_expected.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation addFFIDMetadata($addFFIDMetadataInput:FFIDMetadataInput!){addFFIDMetadata(addFFIDMetadataInput:$addFFIDMetadataInput){fileId}}",
+  "query": "mutation addFFIDMetadata($addFFIDMetadataInput:FFIDMetadataInputValues!){addFFIDMetadata(addFFIDMetadataInput:$addFFIDMetadataInput){fileId}}",
   "variables": {
     "addFFIDMetadataInput": {
       "fileId": "44aaeffb-41b6-4250-97d5-f8c4aebf00a1",

--- a/src/test/resources/json/graphql_valid_ffid_multiple_records_expected_1.json
+++ b/src/test/resources/json/graphql_valid_ffid_multiple_records_expected_1.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation addFFIDMetadata($addFFIDMetadataInput:FFIDMetadataInput!){addFFIDMetadata(addFFIDMetadataInput:$addFFIDMetadataInput){fileId}}",
+  "query": "mutation addFFIDMetadata($addFFIDMetadataInput:FFIDMetadataInputValues!){addFFIDMetadata(addFFIDMetadataInput:$addFFIDMetadataInput){fileId}}",
   "variables": {
     "addFFIDMetadataInput": {
       "fileId": "44aaeffb-41b6-4250-97d5-f8c4aebf00a1",

--- a/src/test/resources/json/graphql_valid_ffid_multiple_records_expected_2.json
+++ b/src/test/resources/json/graphql_valid_ffid_multiple_records_expected_2.json
@@ -1,5 +1,5 @@
 {
-  "query": "mutation addFFIDMetadata($addFFIDMetadataInput:FFIDMetadataInput!){addFFIDMetadata(addFFIDMetadataInput:$addFFIDMetadataInput){fileId}}",
+  "query": "mutation addFFIDMetadata($addFFIDMetadataInput:FFIDMetadataInputValues!){addFFIDMetadata(addFFIDMetadataInput:$addFFIDMetadataInput){fileId}}",
   "variables": {
     "addFFIDMetadataInput": {
       "fileId": "942ae85c-5f2a-4d70-b919-f6e14acf3f07",


### PR DESCRIPTION
I changed the input type names in the API. This worked when making
requests through postman but I think sangria is doing some proper type
checking so this update is needed to get it to work with the API again.

This will fix integration. We'll have to be careful deploying this
change and the API on prod because it will break if they're not deployed
together.
