### PR TITLE
Update consignment status on overwrite.

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -34,11 +34,12 @@ class LambdaTest extends ExternalServicesTest {
     lambda.update(inputStream, new ByteArrayOutputStream())
 
     val serveEvents = wiremockGraphqlServer.getAllServeEvents.asScala
-    serveEvents.size should equal(4)
+    serveEvents.size should equal(5)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addBulkAntivirusMetadata")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addBulkFFIDMetadata")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addMultipleFileMetadata")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addConsignmentStatus")) should equal(1)
+    serveEvents.count(_.getRequest.getBodyAsString.contains("updateConsignmentStatus")) should equal(1)
   }
 
   "The update method" should "return an error if there is an error from keycloak" in {
@@ -118,7 +119,12 @@ class LambdaTest extends ExternalServicesTest {
     Input(
       List(File(fileId, UUID.randomUUID(), UUID.randomUUID(), "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid))),
       RedactedResult(RedactedFilePairs(UUID.randomUUID(), "original", fileId, "redacted") :: Nil, Nil),
-      Statuses(Status(UUID.randomUUID(), "Consignment", "Status", "StatusValue", overwrite = false) :: Nil),
+      Statuses(
+        List(
+          Status(UUID.randomUUID(), "Consignment", "Status", "StatusValue", overwrite = false),
+          Status(UUID.randomUUID(), "Consignment", "OverwriteStatus", "OverwriteStatusValue", overwrite = true)
+        )
+      )
     ).asJson.printWith(Printer.noSpaces)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/api/update/utils/ExternalServicesTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/utils/ExternalServicesTest.scala
@@ -43,7 +43,7 @@ class ExternalServicesTest extends AnyFlatSpec with BeforeAndAfterEach with Befo
       .willReturn(okJson(fromResource(s"json/checksum_response.json").mkString)))
 
     wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
-      .withRequestBody(containing("addConsignmentStatus"))
+      .withRequestBody(containing("ConsignmentStatus"))
       .willReturn(okJson(fromResource(s"json/consignment_status_response.json").mkString)))
   }
 


### PR DESCRIPTION
There is an overwrite parameter in the incoming json which should update
the consignment status when it's set to true. It wasn't doing that
before.
