### PR TITLE
Update to read and write from S3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ ThisBuild / organizationName := "api-update"
 
 libraryDependencies ++= Seq(
   awsSsm,
+  backendCheckUtils,
   circeCore,
   circeGeneric,
   circeParser,
@@ -26,7 +27,7 @@ libraryDependencies ++= Seq(
 
 (Test / fork) := true
 (Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
-(Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test")
+(Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test", "S3_ENDPOINT" -> "http://localhost:9005")
 
 (assembly / assemblyMergeStrategy) := {
   case PathList("META-INF", xs@_*) => MergeStrategy.discard

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   private val awsUtilsVersion = "0.1.65"
 
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.19.21"
+  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.14"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion

--- a/src/main/scala/uk/gov/nationalarchives/api/update/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/LambdaRunner.scala
@@ -4,70 +4,10 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 object LambdaRunner extends App {
   val body =
-    """
-      |{
-      |  "results": [
-      |    {
-      |      "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |      "originalPath": "smallfile/subfolder/subfolder-nested/subfolder-nested-1.txt",
-      |      "fileSize": "2",
-      |      "clientChecksum": "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7",
-      |      "consignmentType": "standard",
-      |      "consignmentId": "cedba409-c806-439f-8982-943afb03c85a",
-      |      "userId": "030cf12c-8d5d-46b9-b86a-38e0920d0e1a",
-      |      "fileCheckResults": {
-      |        "antivirus": [
-      |          {
-      |            "software": "yara",
-      |            "softwareVersion": "4.2.0",
-      |            "databaseVersion": "$LATEST",
-      |            "result": "",
-      |            "datetime": 1670411830303,
-      |            "fileId": "20d80488-d247-47cf-8687-be26de2558b5"
-      |          }
-      |        ],
-      |        "checksum": [
-      |          {
-      |            "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |            "sha256Checksum": "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
-      |          }
-      |        ],
-      |        "fileFormat": [
-      |          {
-      |            "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |            "software": "Droid",
-      |            "softwareVersion": "6.6.0-rc2",
-      |            "binarySignatureFileVersion": "109",
-      |            "containerSignatureFileVersion": "20221102",
-      |            "method": "pronom",
-      |            "matches": [
-      |              {
-      |                "extension": "txt",
-      |                "identificationBasis": "Extension",
-      |                "puid": "x-fmt/111"
-      |              }
-      |            ]
-      |          }
-      |        ]
-      |      }
-      |    }
-      |  ],
-      |  "redactedResults": {
-      |    "redactedFiles": [],
-      |    "errors": []
-      |  },
-      |  "statuses": {
-      |    "statuses": [
-      |      {
-      |        "id": "12edbedc-48e1-4342-846a-fb772289790c",
-      |        "statusType": "File",
-      |        "statusName": "FFID",
-      |        "statusValue": "Success",
-      |        "overwrite": false
-      |      }
-      |    ]
-      |  }
-      |}
+"""{
+  |  "key": "a4c0e084-7562-46dd-9724-92ac9b64d149/7f068a2a-e2c8-472f-bb05-daed89f8de3c/results.json",
+  |  "bucket": "tdr-backend-checks-intg"
+  |}
       |""".stripMargin
 
   val baos = new ByteArrayInputStream(body.getBytes())

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -1,14 +1,14 @@
 package uk.gov.nationalarchives.api.update
 
 import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlEqualTo}
-import graphql.codegen.types.{AddAntivirusMetadataInputValues, FFIDMetadataInputValues}
-import io.circe.Printer
+import com.github.tomakehurst.wiremock.http.RequestMethod
+import io.circe.Printer.noSpaces
 import io.circe.generic.auto._
-import io.circe.parser.decode
 import io.circe.syntax._
+import io.circe.parser.decode
 import org.scalatest.matchers.should.Matchers._
 import sttp.client3.HttpError
-import uk.gov.nationalarchives.api.update.Lambda._
+import uk.gov.nationalarchives.BackendCheckUtils._
 import uk.gov.nationalarchives.api.update.utils.ExternalServicesTest
 import uk.gov.nationalarchives.tdr.error.HttpException
 
@@ -27,9 +27,10 @@ class LambdaTest extends ExternalServicesTest {
   "The update method" should "send metadata to the API" in {
     graphqlOkJson()
     authOkJson()
+    val s3Input = setupS3()
     val lambda = new Lambda()
 
-    val inputStream = new ByteArrayInputStream(getInputJson().getBytes())
+    val inputStream = new ByteArrayInputStream(s3Input.getBytes())
 
     lambda.update(inputStream, new ByteArrayOutputStream())
 
@@ -44,8 +45,9 @@ class LambdaTest extends ExternalServicesTest {
 
   "The update method" should "return an error if there is an error from keycloak" in {
     authUnavailable
+    val s3Input = setupS3()
 
-    val inputStream = new ByteArrayInputStream(getInputJson().getBytes())
+    val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val ex = intercept[HttpError[String]] {
       new Lambda().update(inputStream, new ByteArrayOutputStream())
     }
@@ -55,8 +57,8 @@ class LambdaTest extends ExternalServicesTest {
   "The update method" should "return an error if there is an error from the API" in {
     authOkJson()
     graphqlUnavailable
-
-    val inputStream = new ByteArrayInputStream(getInputJson().getBytes())
+    val s3Input = setupS3()
+    val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val ex = intercept[HttpException] {
       new Lambda().update(inputStream, new ByteArrayOutputStream())
     }
@@ -64,17 +66,18 @@ class LambdaTest extends ExternalServicesTest {
   }
 
   "The update method" should "return the correct json" in {
+    val fileId = UUID.fromString("2ecc4d46-9c8b-46cd-b2a4-8ac2a52001b3")
+    val s3Input = setupS3(fileId)
     authOkJson()
     graphqlOkJson()
-    val fileId = UUID.fromString("2ecc4d46-9c8b-46cd-b2a4-8ac2a52001b3")
-    val inputStream = new ByteArrayInputStream(getInputJson(fileId).getBytes())
+    val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val outputStream = new ByteArrayOutputStream()
     new Lambda().update(inputStream, outputStream)
-    val result = decode[Result](outputStream.toByteArray.map(_.toChar).mkString).toOption.get
+    val result = results.head.fileCheckResults
 
-    val av = result.antivirus.addBulkAntivirusMetadata
-    val file = result.file.addMultipleFileMetadata
-    val ffid = result.ffid.addBulkFFIDMetadata
+    val av = result.antivirus
+    val file = result.checksum
+    val ffid = result.fileFormat
 
     av.size should equal(1)
     file.size should equal(1)
@@ -87,13 +90,12 @@ class LambdaTest extends ExternalServicesTest {
 
   "The getInputs method" should "return the correct results for valid json" in {
     val fileId = UUID.randomUUID()
-    val json = getInputJson(fileId)
-    val inputStream = new ByteArrayInputStream(json.getBytes())
-    val inputs = new Lambda().getInputs(inputStream).futureValue
-
-    val avInput = inputs.results.flatMap(_.fileCheckResults.antivirus)
-    val fileMetadataInput = inputs.results.flatMap(_.fileCheckResults.checksum)
-    val ffidInput = inputs.results.flatMap(_.fileCheckResults.fileFormat)
+    val s3Input = setupS3(fileId)
+    val inputStream = new ByteArrayInputStream(s3Input.getBytes())
+    val (input, _) = new Lambda().getInput(inputStream).futureValue
+    val avInput = input.results.flatMap(_.fileCheckResults.antivirus)
+    val fileMetadataInput = input.results.flatMap(_.fileCheckResults.checksum)
+    val ffidInput = input.results.flatMap(_.fileCheckResults.fileFormat)
 
     avInput.size should equal(1)
     fileMetadataInput.size should equal(1)
@@ -108,23 +110,35 @@ class LambdaTest extends ExternalServicesTest {
   "The getInputs method" should "return an error for invalid json" in {
     val json = "{}"
     val inputStream = new ByteArrayInputStream(json.getBytes())
-    val ex = new Lambda().getInputs(inputStream).failed.futureValue
-    ex.getMessage should equal("Missing required field: DownField(results)")
+    val ex = new Lambda().getInput(inputStream).failed.futureValue
+    ex.getMessage should equal("Missing required field: DownField(key)")
   }
 
+  def setupS3(fileId: UUID = UUID.randomUUID()): String = {
+    val inputJson = getInputJson(fileId)
+    val s3Input = S3Input("testKey", "testBucket")
+    putJsonFile(s3Input, inputJson).asJson.printWith(noSpaces)
+  }
+
+  def results: List[File] = wiremockS3Server.getAllServeEvents.asScala.find(_.getRequest.getMethod == RequestMethod.PUT)
+    .flatMap(ev => {
+      val bodyString = ev.getRequest.getBodyAsString.split("\r\n")(1)
+      decode[List[File]](bodyString).toOption
+    }).getOrElse(Nil)
+
   private def getInputJson(fileId: UUID = UUID.randomUUID()): String = {
-    val ffid = FFIDMetadataInputValues(fileId, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion", "method", Nil) :: Nil
+    val ffid = FFID(fileId, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion", "method", Nil) :: Nil
     val checksum = ChecksumResult("checksum", fileId) :: Nil
-    val av = AddAntivirusMetadataInputValues(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
+    val av = Antivirus(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
     Input(
-      List(File(fileId, UUID.randomUUID(), UUID.randomUUID(), "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid))),
-      RedactedResult(RedactedFilePairs(UUID.randomUUID(), "original", fileId, "redacted") :: Nil, Nil),
-      Statuses(
+      List(File(UUID.randomUUID(), fileId, UUID.randomUUID(), "standard", "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid))),
+      RedactedResults(RedactedFilePairs(UUID.randomUUID(), "original", fileId, "redacted") :: Nil, Nil),
+      StatusResult(
         List(
           Status(UUID.randomUUID(), "Consignment", "Status", "StatusValue", overwrite = false),
           Status(UUID.randomUUID(), "Consignment", "OverwriteStatus", "OverwriteStatusValue", overwrite = true)
         )
       )
-    ).asJson.printWith(Printer.noSpaces)
+    ).asJson.printWith(noSpaces)
   }
 }


### PR DESCRIPTION
This lambda is now running in a step function.

There is a size limit of 256Kb for messages passed between steps and for large consignments, the message is more than this.

To solve this, each step reads its input from S3 and once it has carried out its step, writes the new output to S3 again.

I've updated this lambda to use the backend-check-utils classes and
updated the test to work with calls to S3.
