### PR TITLE
TDR-2824 - Droid extention mismatch 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.339"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.341"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.120"
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.4.11"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   private val awsUtilsVersion = "0.1.65"
 
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.20.1"
-  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.20"
+  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.22"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -108,7 +108,7 @@ class Lambda {
     abfim.Variables(FFIDMetadataInput(input.results
       .flatMap(_.fileCheckResults.fileFormat
         .map(ff => {
-          val matches = ff.matches.map(m => FFIDMetadataInputMatches(m.extension, m.identificationBasis, m.puid, Option(false), Option("")))
+          val matches = ff.matches.map(m => FFIDMetadataInputMatches(m.extension, m.identificationBasis, m.puid, m.fileExtensionMismatch, m.formatName))
           FFIDMetadataInputValues(ff.fileId, ff.software, ff.softwareVersion ,ff.binarySignatureFileVersion, ff.containerSignatureFileVersion, ff.method, matches)
         }))))
   }

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -108,7 +108,7 @@ class Lambda {
     abfim.Variables(FFIDMetadataInput(input.results
       .flatMap(_.fileCheckResults.fileFormat
         .map(ff => {
-          val matches = ff.matches.map(m => FFIDMetadataInputMatches(m.extension, m.identificationBasis, m.puid, m.fileExtentionMismatch, m.formatName))
+          val matches = ff.matches.map(m => FFIDMetadataInputMatches(m.extension, m.identificationBasis, m.puid, Option(false), Option("")))
           FFIDMetadataInputValues(ff.fileId, ff.software, ff.softwareVersion ,ff.binarySignatureFileVersion, ff.containerSignatureFileVersion, ff.method, matches)
         }))))
   }

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -108,7 +108,7 @@ class Lambda {
     abfim.Variables(FFIDMetadataInput(input.results
       .flatMap(_.fileCheckResults.fileFormat
         .map(ff => {
-          val matches = ff.matches.map(m => FFIDMetadataInputMatches(m.extension, m.identificationBasis, m.puid))
+          val matches = ff.matches.map(m => FFIDMetadataInputMatches(m.extension, m.identificationBasis, m.puid, m.fileExtentionMismatch, m.formatName))
           FFIDMetadataInputValues(ff.fileId, ff.software, ff.softwareVersion ,ff.binarySignatureFileVersion, ff.containerSignatureFileVersion, ff.method, matches)
         }))))
   }

--- a/src/test/resources/json/ffid_response.json
+++ b/src/test/resources/json/ffid_response.json
@@ -11,7 +11,9 @@
           {
             "puid": "x-fmt/111",
             "identificationBasis": "Some basis",
-            "extension": "txt"
+            "extension": "txt",
+            "fileExtensionMismatch": false,
+            "formatName": "format-name"
           }
         ],
         "containerSignatureFileVersion": "container-signature-20200121.xml",

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -86,6 +86,7 @@ class LambdaTest extends ExternalServicesTest {
     file.head.fileId should equal(fileId)
     file.last.fileId should equal(fileId)
     ffid.head.fileId should equal(fileId)
+    ffid.head.matches.size should equal(1)
   }
 
   "The getInputs method" should "return the correct results for valid json" in {
@@ -105,6 +106,14 @@ class LambdaTest extends ExternalServicesTest {
     fileMetadataInput.head.fileId should equal(fileId)
     fileMetadataInput.last.fileId should equal(fileId)
     ffidInput.head.fileId should equal(fileId)
+
+    val ffidMatches = ffidInput.head.matches
+    ffidMatches.size should equal(1)
+    ffidMatches.head.formatName should equal(Some("format-name"))
+    ffidMatches.head.fileExtensionMismatch should equal(Some(false))
+    ffidMatches.head.puid should equal(Some("x-fmt/111"))
+    ffidMatches.head.extension should equal(Some("txt"))
+    ffidMatches.head.identificationBasis should equal("Some basis")
   }
 
   "The getInputs method" should "return an error for invalid json" in {
@@ -127,7 +136,8 @@ class LambdaTest extends ExternalServicesTest {
     }).getOrElse(Nil)
 
   private def getInputJson(fileId: UUID = UUID.randomUUID()): String = {
-    val ffid = FFID(fileId, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion", "method", Nil) :: Nil
+    val ffidMatch = FFIDMetadataInputMatches(Some("txt"), "Some basis", Some("x-fmt/111"), Some(false), Some("format-name"))
+    val ffid = FFID(fileId, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion", "method", ffidMatch :: Nil) :: Nil
     val checksum = ChecksumResult("checksum", fileId) :: Nil
     val av = Antivirus(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
     Input(


### PR DESCRIPTION
Requires PR: https://github.com/nationalarchives/tdr-backend-checks-utils/pull/45

- [x] Updated schema version
- [x] Updated object with default values as input object doesn't have any attributes to populate the object. 