### PR TITLE
Increase await results timeout

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -126,6 +126,6 @@ class Lambda {
     } yield {
       output.write(inputStream.readAllBytes())
     }
-    Await.result(result, 60.seconds)
+    Await.result(result, 90.seconds)
   }
 }


### PR DESCRIPTION
Testing a 3000 file transfer the lambda is timing out but the transfer overall succeeds