### PR TITLE
Remove writing results back after update complete

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -9,10 +9,8 @@ import graphql.codegen.AddMultipleFileMetadata.{addMultipleFileMetadata => amfm}
 import graphql.codegen.AddMultipleFileStatuses.{addMultipleFileStatuses => amfs}
 import graphql.codegen.UpdateConsignmentStatus.{updateConsignmentStatus => ucs}
 import graphql.codegen.types.{FFIDMetadataInputMatches, _}
-import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.parser.decode
-import io.circe.syntax._
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.SsmClient
@@ -39,7 +37,6 @@ class Lambda {
   private val endpoint = sys.env("S3_ENDPOINT")
 
   val backendCheckUtils: BackendCheckUtils = BackendCheckUtils(endpoint)
-
 
   def getClientSecret(secretPath: String, endpoint: String): String = {
     val httpClient = ApacheHttpClient.builder.build
@@ -91,12 +88,6 @@ class Lambda {
     } yield input.statuses
   }
 
-  def writeResults(resultJson: String, s3Input: S3Input): Future[S3Input] =
-    backendCheckUtils.writeResultJson(s3Input.key, s3Input.bucket, resultJson) match {
-      case Left(err) => Future.failed(err)
-      case Right(value) => Future.successful(value)
-    }
-
   def avVariables(input: Input): avbm.Variables = {
     val avResults: List[AddAntivirusMetadataInputValues] = input.results
       .flatMap(_.fileCheckResults.antivirus
@@ -116,13 +107,12 @@ class Lambda {
   def update(inputStream: InputStream, output: OutputStream): Unit = {
 
     val result = for {
-      (input, s3Input) <- getInput(inputStream)
+      (input, _) <- getInput(inputStream)
       token <- keycloakUtils.serviceAccountToken(config("client.id"), clientSecret)
       _: avbm.Data <- RequestSender[avbm.Data, avbm.Variables].sendRequest(token, avbm.document, avVariables(input))
       _: amfm.Data <- RequestSender[amfm.Data, amfm.Variables].sendRequest(token, amfm.document, amfm.Variables(AddFileMetadataWithFileIdInput(getFileMetadata(input))))
       _: abfim.Data <- RequestSender[abfim.Data, abfim.Variables].sendRequest(token, abfim.document, ffidVariables(input))
       _ <- sendStatuses(input, token)
-      _ <- writeResults(input.results.asJson.printWith(Printer.noSpaces), s3Input)
     } yield {
       output.write(inputStream.readAllBytes())
     }

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -65,30 +65,6 @@ class LambdaTest extends ExternalServicesTest {
     ex.getMessage.contains("Unexpected response from GraphQL API: Response(Left(),500,Server Error") should equal(true)
   }
 
-  "The update method" should "return the correct json" in {
-    val fileId = UUID.fromString("2ecc4d46-9c8b-46cd-b2a4-8ac2a52001b3")
-    val s3Input = setupS3(fileId)
-    authOkJson()
-    graphqlOkJson()
-    val inputStream = new ByteArrayInputStream(s3Input.getBytes())
-    val outputStream = new ByteArrayOutputStream()
-    new Lambda().update(inputStream, outputStream)
-    val result = results.head.fileCheckResults
-
-    val av = result.antivirus
-    val file = result.checksum
-    val ffid = result.fileFormat
-
-    av.size should equal(1)
-    file.size should equal(1)
-    ffid.size should equal(1)
-    av.head.fileId should equal(fileId)
-    file.head.fileId should equal(fileId)
-    file.last.fileId should equal(fileId)
-    ffid.head.fileId should equal(fileId)
-    ffid.head.matches.size should equal(1)
-  }
-
   "The getInputs method" should "return the correct results for valid json" in {
     val fileId = UUID.randomUUID()
     val s3Input = setupS3(fileId)


### PR DESCRIPTION
The writing of the results back to the s3 bucket after completion of updating the metadata for large consignments is causing the Lambda to time out

It currently serves no purpose to do this and it is also memory intensive to do so

Remove this step to improve the performance