### PR TITLE
TDRD-148: batch the files status updates (batches of 10,000)

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -129,6 +129,6 @@ class Lambda {
     } yield {
       output.write(inputStream.readAllBytes())
     }
-    Await.result(result, 600.seconds)
+    Await.result(result, 480.seconds)
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -24,6 +24,7 @@ import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeploymen
 
 import java.io.{InputStream, OutputStream}
 import java.net.URI
+import java.util.Calendar
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
@@ -113,7 +114,7 @@ class Lambda {
   }
 
   def update(inputStream: InputStream, output: OutputStream): Unit = {
-
+    println("=A=>" + Calendar.getInstance())
     val result = for {
       (input, s3Input) <- getInput(inputStream)
       token <- keycloakUtils.serviceAccountToken(config("client.id"), clientSecret)
@@ -125,6 +126,8 @@ class Lambda {
     } yield {
       output.write(inputStream.readAllBytes())
     }
-    Await.result(result, 90.seconds)
+    println("=B=>" + Calendar.getInstance())
+    Await.result(result, 1200.seconds)
+    println("=C=>" + Calendar.getInstance())
   }
 }

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -37,6 +37,7 @@ class Lambda {
   implicit val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
   private val endpoint = sys.env("S3_ENDPOINT")
+  private val batchSizeForFileStatusUpdates = 10000
 
   val backendCheckUtils: BackendCheckUtils = BackendCheckUtils(endpoint)
 
@@ -82,7 +83,7 @@ class Lambda {
         })
       }
       _ <- if (fileStatuses.nonEmpty) {
-        val resultingFutures = fileStatuses.grouped(10000).map { fsGroup =>
+        val resultingFutures = fileStatuses.grouped(batchSizeForFileStatusUpdates).map { fsGroup =>
           val fileStatusVariables = amfs.Variables(AddMultipleFileStatusesInput(fsGroup.map(fs => AddFileStatusInput(fs.id, fs.statusName, fs.statusValue))))
           RequestSender[amfs.Data, amfs.Variables].sendRequest(token, amfs.document, fileStatusVariables)
         }


### PR DESCRIPTION
for 10,000 files testing the step to update file statuses includes 70,000 in one call, generating lots of waits for write ahead log activity and timeouts... takes around 8 mins.

batching into groups of 10,000 in each call runs without noticeable write ahead log waits and each call completes in around 30 secs.  