### PR TITLE
Handle optional s3 source state fields

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   private val awsUtilsVersion = "0.1.65" 
 
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.31.61"
-  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.111"
+  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.112"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion


### PR DESCRIPTION
In the unit tests the 'deepDropNullValues' in constructing in input json is used to ensure the s3 source state field do not appear in the constructed json

This accurately reflects the scenario where the read json for s3 does not contain these fields