### PR TITLE
Fix decoding failure

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -24,6 +24,7 @@ import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeploymen
 
 import java.io.{InputStream, OutputStream}
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
@@ -41,7 +42,7 @@ class Lambda {
 
   val backendCheckUtils: BackendCheckUtils = BackendCheckUtils(endpoint)
 
-  def getClientSecret(secretPath: String, endpoint: String): String = {
+  private def getClientSecret(secretPath: String, endpoint: String): String = {
     val httpClient = ApacheHttpClient.builder.build
     val ssmClient: SsmClient = SsmClient.builder()
       .endpointOverride(URI.create(endpoint))
@@ -61,15 +62,24 @@ class Lambda {
       case Right(inputs) => Future.successful(inputs)
     }
 
-  def getFileMetadata(input: Input): List[AddFileMetadataWithFileIdInputValues] = {
+  private def getFileMetadata(input: Input): List[AddFileMetadataWithFileIdInputValues] = {
     input.results.flatMap(_.fileCheckResults.checksum.map(c => AddFileMetadataWithFileIdInputValues("SHA256ServerSideChecksum", c.fileId, c.sha256Checksum))) ++
     input.redactedResults.redactedFiles.map(r => AddFileMetadataWithFileIdInputValues("OriginalFilepath", r.redactedFileId, r.originalFilePath))
   }
 
-  def sendStatuses(input: Input, token: BearerAccessToken): Future[StatusResult] = {
+  private def sendStatuses(input: Input, token: BearerAccessToken): Future[StatusResult] = {
     val (consignmentStatuses, fileStatuses) = input.statuses.statuses.partition(_.statusType == "Consignment")
 
     for {
+      _ <- if (fileStatuses.nonEmpty) {
+        val resultingFutures = fileStatuses.grouped(batchSizeForFileStatusUpdates).map { fsGroup =>
+          val fileStatusVariables = amfs.Variables(AddMultipleFileStatusesInput(fsGroup.map(fs => AddFileStatusInput(fs.id, fs.statusName, fs.statusValue))))
+          RequestSender[amfs.Data, amfs.Variables].sendRequest(token, amfs.document, fileStatusVariables)
+        }
+        Future.sequence(resultingFutures)
+      } else {
+        Future.successful(())
+      }
       _ <- Future.sequence {
         consignmentStatuses.map(consignmentStatus => {
           val statusInput = ConsignmentStatusInput(consignmentStatus.id, consignmentStatus.statusName, Option(consignmentStatus.statusValue), None)
@@ -82,32 +92,23 @@ class Lambda {
           }
         })
       }
-      _ <- if (fileStatuses.nonEmpty) {
-        val resultingFutures = fileStatuses.grouped(batchSizeForFileStatusUpdates).map { fsGroup =>
-          val fileStatusVariables = amfs.Variables(AddMultipleFileStatusesInput(fsGroup.map(fs => AddFileStatusInput(fs.id, fs.statusName, fs.statusValue))))
-          RequestSender[amfs.Data, amfs.Variables].sendRequest(token, amfs.document, fileStatusVariables)
-        }
-        Future.sequence(resultingFutures)
-      } else {
-        Future()
-      }
     } yield input.statuses
   }
 
-  def writeResults(resultJson: String, s3Input: S3Input): Future[S3Input] =
+  private def writeResults(resultJson: String, s3Input: S3Input): Future[S3Input] =
     backendCheckUtils.writeResultJson(s3Input.key, s3Input.bucket, resultJson) match {
       case Left(err) => Future.failed(err)
       case Right(value) => Future.successful(value)
     }
 
-  def avVariables(input: Input): avbm.Variables = {
+  private def avVariables(input: Input): avbm.Variables = {
     val avResults: List[AddAntivirusMetadataInputValues] = input.results
       .flatMap(_.fileCheckResults.antivirus
         .map(av => AddAntivirusMetadataInputValues(av.fileId, av.software, av.softwareVersion, av.databaseVersion, av.result, av.datetime)))
     avbm.Variables(AddAntivirusMetadataInput(avResults))
   }
 
-  def ffidVariables(input: Input): abfim.Variables = {
+  private def ffidVariables(input: Input): abfim.Variables = {
     abfim.Variables(FFIDMetadataInput(input.results
       .flatMap(_.fileCheckResults.fileFormat
         .map(ff => {
@@ -120,14 +121,15 @@ class Lambda {
 
     val result = for {
       (input, s3Input) <- getInput(inputStream)
+      resultJson = input.results.asJson.printWith(Printer.noSpaces)
       token <- keycloakUtils.serviceAccountToken(config("client.id"), clientSecret)
       _: avbm.Data <- RequestSender[avbm.Data, avbm.Variables].sendRequest(token, avbm.document, avVariables(input))
       _: amfm.Data <- RequestSender[amfm.Data, amfm.Variables].sendRequest(token, amfm.document, amfm.Variables(AddFileMetadataWithFileIdInput(getFileMetadata(input))))
       _: abfim.Data <- RequestSender[abfim.Data, abfim.Variables].sendRequest(token, abfim.document, ffidVariables(input))
       _ <- sendStatuses(input, token)
-      _ <- writeResults(input.results.asJson.printWith(Printer.noSpaces), s3Input)
+      _ <- writeResults(resultJson, s3Input)
     } yield {
-      output.write(inputStream.readAllBytes())
+      output.write(resultJson.getBytes(StandardCharsets.UTF_8))
     }
     Await.result(result, 480.seconds)
   }

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -76,9 +76,9 @@ class Lambda {
           val fileStatusVariables = amfs.Variables(AddMultipleFileStatusesInput(fsGroup.map(fs => AddFileStatusInput(fs.id, fs.statusName, fs.statusValue))))
           RequestSender[amfs.Data, amfs.Variables].sendRequest(token, amfs.document, fileStatusVariables)
         }
-        Future.sequence(resultingFutures)
+        Future.sequence(resultingFutures).map(_ => ())
       } else {
-        Future.successful(())
+        Future.unit
       }
       _ <- Future.sequence {
         consignmentStatuses.map(consignmentStatus => {

--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -122,6 +122,7 @@ class Lambda {
     val result = for {
       (input, s3Input) <- getInput(inputStream)
       resultJson = input.results.asJson.printWith(Printer.noSpaces)
+      outputJson = input.asJson.deepDropNullValues.printWith(Printer.noSpaces)
       token <- keycloakUtils.serviceAccountToken(config("client.id"), clientSecret)
       _: avbm.Data <- RequestSender[avbm.Data, avbm.Variables].sendRequest(token, avbm.document, avVariables(input))
       _: amfm.Data <- RequestSender[amfm.Data, amfm.Variables].sendRequest(token, amfm.document, amfm.Variables(AddFileMetadataWithFileIdInput(getFileMetadata(input))))
@@ -129,7 +130,7 @@ class Lambda {
       _ <- sendStatuses(input, token)
       _ <- writeResults(resultJson, s3Input)
     } yield {
-      output.write(resultJson.getBytes(StandardCharsets.UTF_8))
+      output.write(outputJson.getBytes(StandardCharsets.UTF_8))
     }
     Await.result(result, 480.seconds)
   }

--- a/src/test/resources/json/file_status_response.json
+++ b/src/test/resources/json/file_status_response.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "addMultipleFileStatuses": [
+      {
+        "fileId": "2ecc4d46-9c8b-46cd-b2a4-8ac2a52001b3",
+        "statusType": "FileStatus",
+        "statusValue": "FileStatusValue"
+      }
+    ]
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -13,6 +13,7 @@ import uk.gov.nationalarchives.api.update.utils.ExternalServicesTest
 import uk.gov.nationalarchives.tdr.error.HttpException
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
 
@@ -82,7 +83,7 @@ class LambdaTest extends ExternalServicesTest {
     val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val outputStream = new ByteArrayOutputStream()
     new Lambda().update(inputStream, outputStream)
-    outputStream.toString should equal(results.asJson.printWith(noSpaces))
+    outputStream.toString(StandardCharsets.UTF_8) should equal(results.asJson.printWith(noSpaces))
 
     results.head.s3SourceBucket.get should equal("source-bucket")
     results.head.s3SourceBucketKey.get should equal("source/object/key")

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -35,12 +35,21 @@ class LambdaTest extends ExternalServicesTest {
     lambda.update(inputStream, new ByteArrayOutputStream())
 
     val serveEvents = wiremockGraphqlServer.getAllServeEvents.asScala
-    serveEvents.size should equal(5)
+    serveEvents.size should equal(6)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addBulkAntivirusMetadata")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addBulkFFIDMetadata")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addMultipleFileMetadata")) should equal(1)
+    serveEvents.count(_.getRequest.getBodyAsString.contains("addMultipleFileStatuses")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("addConsignmentStatus")) should equal(1)
     serveEvents.count(_.getRequest.getBodyAsString.contains("updateConsignmentStatus")) should equal(1)
+
+    val statusRequestBodies = serveEvents.toList
+      .sortBy(_.getRequest.getLoggedDate)
+      .map(_.getRequest.getBodyAsString)
+      .filter(body => body.contains("addMultipleFileStatuses") || body.contains("ConsignmentStatus"))
+
+    statusRequestBodies.head should include("addMultipleFileStatuses")
+    statusRequestBodies.tail.foreach(_ should not include "addMultipleFileStatuses")
   }
 
   "The update method" should "return an error if there is an error from keycloak" in {
@@ -73,6 +82,7 @@ class LambdaTest extends ExternalServicesTest {
     val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val outputStream = new ByteArrayOutputStream()
     new Lambda().update(inputStream, outputStream)
+    outputStream.toString should equal(results.asJson.printWith(noSpaces))
 
     results.head.s3SourceBucket.get should equal("source-bucket")
     results.head.s3SourceBucketKey.get should equal("source/object/key")
@@ -209,7 +219,8 @@ class LambdaTest extends ExternalServicesTest {
       StatusResult(
         List(
           Status(UUID.randomUUID(), "Consignment", "Status", "StatusValue", overwrite = false),
-          Status(UUID.randomUUID(), "Consignment", "OverwriteStatus", "OverwriteStatusValue", overwrite = true)
+          Status(UUID.randomUUID(), "Consignment", "OverwriteStatus", "OverwriteStatusValue", overwrite = true),
+          Status(fileId, "File", "FileStatus", "FileStatusValue", overwrite = false)
         )
       )
     ).asJson.deepDropNullValues.printWith(noSpaces)

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -83,7 +83,8 @@ class LambdaTest extends ExternalServicesTest {
     val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val outputStream = new ByteArrayOutputStream()
     new Lambda().update(inputStream, outputStream)
-    outputStream.toString(StandardCharsets.UTF_8) should equal(results.asJson.printWith(noSpaces))
+    val decodedOutput = decode[Input](outputStream.toString(StandardCharsets.UTF_8)).toOption.get
+    decodedOutput.results should equal(results)
 
     results.head.s3SourceBucket.get should equal("source-bucket")
     results.head.s3SourceBucketKey.get should equal("source/object/key")

--- a/src/test/scala/uk/gov/nationalarchives/api/update/utils/ExternalServicesTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/utils/ExternalServicesTest.scala
@@ -55,6 +55,10 @@ class ExternalServicesTest extends AnyFlatSpec with BeforeAndAfterEach with Befo
       .willReturn(okJson(fromResource(s"json/checksum_response.json").mkString)))
 
     wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
+      .withRequestBody(containing("addMultipleFileStatuses"))
+      .willReturn(okJson(fromResource(s"json/file_status_response.json").mkString)))
+
+    wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
       .withRequestBody(containing("ConsignmentStatus"))
       .willReturn(okJson(fromResource(s"json/consignment_status_response.json").mkString)))
   }


### PR DESCRIPTION
 Fix lambda output to include full Input JSON

  The lambda output stream was writing only input.results (a bare JSON array), which caused DecodingFailure at .results: Missing required field in downstream consumers that expect an object with a results field.

  Fix

  Write input.asJson.deepDropNullValues to the output stream so the full Input structure (including results, redactedResults, statuses) is returned. The S3 write remains unchanged.

I think this was the original intention of the code when it used to write inputStream.readAllBytes that didn't actually work because the input stream had been already consumed