### PR TITLE
Fix lambda output to write full Input JSON

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -122,6 +122,7 @@ class Lambda {
     val result = for {
       (input, s3Input) <- getInput(inputStream)
       resultJson = input.results.asJson.printWith(Printer.noSpaces)
+      outputJson = input.asJson.deepDropNullValues.printWith(Printer.noSpaces)
       token <- keycloakUtils.serviceAccountToken(config("client.id"), clientSecret)
       _: avbm.Data <- RequestSender[avbm.Data, avbm.Variables].sendRequest(token, avbm.document, avVariables(input))
       _: amfm.Data <- RequestSender[amfm.Data, amfm.Variables].sendRequest(token, amfm.document, amfm.Variables(AddFileMetadataWithFileIdInput(getFileMetadata(input))))
@@ -129,7 +130,7 @@ class Lambda {
       _ <- sendStatuses(input, token)
       _ <- writeResults(resultJson, s3Input)
     } yield {
-      output.write(resultJson.getBytes(StandardCharsets.UTF_8))
+      output.write(outputJson.getBytes(StandardCharsets.UTF_8))
     }
     Await.result(result, 480.seconds)
   }

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -83,7 +83,8 @@ class LambdaTest extends ExternalServicesTest {
     val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val outputStream = new ByteArrayOutputStream()
     new Lambda().update(inputStream, outputStream)
-    outputStream.toString(StandardCharsets.UTF_8) should equal(results.asJson.printWith(noSpaces))
+    val decodedOutput = decode[Input](outputStream.toString(StandardCharsets.UTF_8)).toOption.get
+    decodedOutput.results should equal(results)
 
     results.head.s3SourceBucket.get should equal("source-bucket")
     results.head.s3SourceBucketKey.get should equal("source/object/key")


### PR DESCRIPTION
The output stream was writing only input.results (a bare JSON array), causing DecodingFailure at .results when downstream consumers tried to decode the output as an Input object with a results field.

Now writes input.asJson.deepDropNullValues which includes the full Input structure (results, redactedResults, statuses).