### PR TITLE
Return only S3Input from lambda to avoid 6MB response limit

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/api/update/Lambda.scala
@@ -24,7 +24,6 @@ import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeploymen
 
 import java.io.{InputStream, OutputStream}
 import java.net.URI
-import java.nio.charset.StandardCharsets
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
@@ -122,16 +121,13 @@ class Lambda {
     val result = for {
       (input, s3Input) <- getInput(inputStream)
       resultJson = input.results.asJson.printWith(Printer.noSpaces)
-      outputJson = input.asJson.deepDropNullValues.printWith(Printer.noSpaces)
       token <- keycloakUtils.serviceAccountToken(config("client.id"), clientSecret)
       _: avbm.Data <- RequestSender[avbm.Data, avbm.Variables].sendRequest(token, avbm.document, avVariables(input))
       _: amfm.Data <- RequestSender[amfm.Data, amfm.Variables].sendRequest(token, amfm.document, amfm.Variables(AddFileMetadataWithFileIdInput(getFileMetadata(input))))
       _: abfim.Data <- RequestSender[abfim.Data, abfim.Variables].sendRequest(token, abfim.document, ffidVariables(input))
       _ <- sendStatuses(input, token)
       _ <- writeResults(resultJson, s3Input)
-    } yield {
-      output.write(outputJson.getBytes(StandardCharsets.UTF_8))
-    }
+    } yield ()
     Await.result(result, 480.seconds)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/api/update/LambdaTest.scala
@@ -83,8 +83,7 @@ class LambdaTest extends ExternalServicesTest {
     val inputStream = new ByteArrayInputStream(s3Input.getBytes())
     val outputStream = new ByteArrayOutputStream()
     new Lambda().update(inputStream, outputStream)
-    val decodedOutput = decode[Input](outputStream.toString(StandardCharsets.UTF_8)).toOption.get
-    decodedOutput.results should equal(results)
+    outputStream.toString(StandardCharsets.UTF_8) should equal("")
 
     results.head.s3SourceBucket.get should equal("source-bucket")
     results.head.s3SourceBucketKey.get should equal("source/object/key")


### PR DESCRIPTION
Problem
 
 The In Progress Status API Update step in TDRBackendChecksV2 failed for large consignments (~10000 files) with DecodingFailure at .results: Missing required field.
 
 Root cause
 
 input.asJson (written to the lambda response by v704) exceeded AWS Lambda's 6MB sync response limit. Sequence:
 
  1. Scala completes writeResults, overwriting the S3 key with a bare results array (this is required for the Map step's ItemReader to iterate).
  2. Lambda runtime fails to return the oversize response and reports invocation failure.
  3. Step Functions retries; every retry decodes the now-bare-array S3 file as Input and fails on .results.
 
 Fix
 
 Return nothing from the lambda. The step function does not consume the output:
 
  - In Progress Status API Update has ResultPath: null (output discarded).
  - Update API is terminal.
 
 This matches v702 behaviour, where readAllBytes() returned 0 bytes because the stream had already been consumed by getInput. writeResults still writes the bare results array to S3 (needed for Map).